### PR TITLE
Fix "canvas not defined" when using click callback.

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -348,6 +348,7 @@ if (!window.clearImmediate) {
     var hovered;
 
     var getInfoGridFromMouseEvent = function getInfoGridFromMouseEvent(evt) {
+      var canvas = evt.target;
       var rect = canvas.getBoundingClientRect();
       var eventX = evt.clientX - rect.left;
       var eventY = evt.clientY - rect.top;


### PR DESCRIPTION
Derived the relevant canvas for the click callback from evt.target.
