### PR TITLE
Pass array of objects including element attributes

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -653,7 +653,7 @@ if (!window.clearImmediate) {
 
     /* Actually draw the text on the grid */
     var drawText = function drawText(gx, gy, info, word, weight,
-                                     distance, theta, rotateDeg) {
+                                     distance, theta, rotateDeg, attributes) {
 
       var fontSize = info.fontSize;
       var color;
@@ -744,6 +744,11 @@ if (!window.clearImmediate) {
           for (var cssProp in styleRules) {
             span.style[cssProp] = styleRules[cssProp];
           }
+          if (attributes) {
+            for (var attribute in attributes) {
+              span.setAttribute(attribute, attributes[attribute]);
+            }
+          }
           el.appendChild(span);
         }
       });
@@ -805,8 +810,15 @@ if (!window.clearImmediate) {
        calculate it's size and determine it's position, and actually
        put it on the canvas. */
     var putWord = function putWord(item) {
-      var word = item[0];
-      var weight = item[1];
+      var word, weight, attributes;
+      if (Array.isArray(item)) {
+        word = item[0];
+        weight = item[1];
+      } else {
+        word = item.word;
+        weight = item.weight;
+        attributes = item.attributes;
+      }
       var rotateDeg = getRotateDeg();
 
       // get info needed to put the text onto the canvas
@@ -847,7 +859,7 @@ if (!window.clearImmediate) {
 
         // Actually put the text on the canvas
         drawText(gx, gy, info, word, weight,
-                 (maxRadius - r), gxy[2], rotateDeg);
+                 (maxRadius - r), gxy[2], rotateDeg, attributes);
 
         // Mark the spaces on the grid as filled
         updateGrid(gx, gy, gw, gh, info, item);


### PR DESCRIPTION
Array of objects can also be passed as list option which makes it possible to add arbitrary attributes to the rendered span elements.

Needed for a project where words represent categories and further details of the categories should be appear on mouse over.

The list array's object must have the properties 'word' and 'weight' and can have an object 'attributes' containing any attributes which should be added to rendered span elements.

**Example from index.html, line 371**

```
list.push({ word: lineArr.join(' '), weight: count, attributes: { title: 'I have a weight of ' + count }});
```
