### PR TITLE
Fix #23 click event broken for HTML

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -361,19 +361,13 @@ if (!window.clearImmediate) {
     var hovered;
 
     var getInfoGridFromMouseEvent = function getInfoGridFromMouseEvent(evt) {
-      var canvas = evt.target;
-      if (!canvas.getContext) {
-          var i = canvas.textContent;
-          var d = { x: 0, y: 0, w: 0, h: 0 }; /* FIXME */
-          var info = { item: i, dimension: d };
-          return info;
-      }
+      var canvas = evt.currentTarget;
       var rect = canvas.getBoundingClientRect();
       var eventX = evt.clientX - rect.left;
       var eventY = evt.clientY - rect.top;
 
-      var x = Math.floor(eventX * (canvas.width / rect.width) / g);
-      var y = Math.floor(eventY * (canvas.height / rect.height) / g);
+      var x = Math.floor(eventX * ((canvas.width / rect.width) || 1) / g);
+      var y = Math.floor(eventY * ((canvas.height / rect.height) || 1) / g);
 
       return infoGrid[x][y];
     };


### PR DESCRIPTION
I removed the ad hoc and replaced canvas.target for canvas.currentTarget.

I just don't get why there is a division with canvas width and rect width as they are always the same, and the division will always be 1. As HTML elements don't have the width or height attribute, I substituted that division for 1 if the division was NaN. There is no need to check if it is a canvas or not.
