### PR TITLE
Customize class in DOM clouds and make hardcoded color optional.

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,7 +32,11 @@ Available options as the property of the `options` object are:
 * `fontFamily`: font to use.
 * `fontWeight`: font weight to use, e.g. `normal`, `bold` or `600`
 * `color`: color of the text, can be any CSS color, or a `callback(word, weight, fontSize, distance, theta)` specifies different color for each item in the list.
-  You may also specify colors with built-in keywords: `random-dark` and `random-light`.
+  You may also specify colors with built-in keywords: `random-dark` and `random-light`. If this is a DOM cloud, color can also be `null` to disable hardcoding of
+  color into span elements (allowing you to customize at the class level).
+* `classes`: for DOM clouds, allows the user to define the class of the span elements. Can be a normal class string,
+  applying the same class to every span or a `callback(word, weight, fontSize, distance, theta)` for per-span class definition.
+  In canvas clouds or if equals `null`, this option has no effect.
 * `minSize`: minimum font size to draw on the canvas.
 * `weightFactor`: function to call or number to multiply for `size` of each word in the list.
 * `clearCanvas`: paint the entire canvas with background color and consider it empty before start.

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -205,6 +205,8 @@ if (!window.clearImmediate) {
       shape: 'circle',
       ellipticity: 0.65,
 
+      classes: null,
+
       hover: null,
       click: null
     };
@@ -353,6 +355,12 @@ if (!window.clearImmediate) {
           getTextColor = settings.color;
         }
         break;
+    }
+
+    /* function for getting the classes of the text */
+    var getTextClasses = null;
+    if (typeof settings.classes === 'function') {
+      getTextClasses = settings.classes;
     }
 
     /* Interactive */
@@ -663,6 +671,13 @@ if (!window.clearImmediate) {
         color = settings.color;
       }
 
+      var classes;
+      if (getTextClasses) {
+        classes = getTextClasses(word, weight, fontSize, distance, theta);
+      } else {
+        classes = settings.classes;
+      }
+
       var dimension;
       var bounds = info.bounds;
       dimension = {
@@ -730,7 +745,6 @@ if (!window.clearImmediate) {
             'top': ((gy + info.gh / 2) * g + info.fillTextOffsetY) + 'px',
             'width': info.fillTextWidth + 'px',
             'height': info.fillTextHeight + 'px',
-            'color': color,
             'lineHeight': fontSize + 'px',
             'whiteSpace': 'nowrap',
             'transform': transformRule,
@@ -740,6 +754,9 @@ if (!window.clearImmediate) {
             'webkitTransformOrigin': '50% 40%',
             'msTransformOrigin': '50% 40%'
           };
+          if (color) {
+            styleRules.color = color;
+          }
           span.textContent = word;
           for (var cssProp in styleRules) {
             span.style[cssProp] = styleRules[cssProp];
@@ -748,6 +765,9 @@ if (!window.clearImmediate) {
             for (var attribute in attributes) {
               span.setAttribute(attribute, attributes[attribute]);
             }
+          }
+          if (classes) {
+            span.className += classes;
           }
           el.appendChild(span);
         }

--- a/test/unit/options.js
+++ b/test/unit/options.js
@@ -96,6 +96,21 @@ test('color can be set as a function', function() {
   WordCloud(setupTest('color-as-function'), options);
 });
 
+test('classes can be set as a function', function() {
+  var options = getTestOptions();
+  options.classes = function (word, weight, fontSize, radius, theta) {
+    if (theta < 2*Math.PI/3) {
+      return 'class1';
+    } else if (theta < 2*Math.PI*2/3) {
+      return 'class2';
+    } else {
+      return 'class3';
+    }
+  };
+
+  WordCloud(setupTest('classes-as-function'), options);
+});
+
 test('shape can be set to circle', function() {
   var options = getTestOptions();
   options.shape = 'circle';


### PR DESCRIPTION
This makes it easier to style shadow-boxes, highlights, popups and so on by making the color CSS configurable.

Example use:
```javascript
var classes = [ "t0", "t1", "t2", "t3", "t4" ];
var classCalculator = function( word, weight, fontSize, distance, theta ) {
	return "tag " + classes[ Math.round( fontSize ) % classes.length ];
}

var options = {
	list: keywords,
	minSize: minFontSize,
	color: null,
	classes: classCalculator,
	gridSize: 16
}
```

Example span in output:
```html
<span class="tag t2" style="position: absolute; display: block; font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: 36.5447px; line-height: 36.5447px; font-family: 'Trebuchet MS', 'Heiti TC', 微軟正黑體, 'Arial Unicode MS', 'Droid Fallback Sans', sans-serif; left: 267.84px; top: 169.382px; width: 104.321px; height: 36.5447px; white-space: nowrap; transform: rotate(0deg); transform-origin: 50% 40% 0px;">health</span>
```