### PR TITLE
Touch devices fix

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -368,7 +368,8 @@ if (!window.clearImmediate) {
     var infoGrid = [];
     var hovered;
 
-    var getInfoGridFromMouseTouchEvent = function getInfoGridFromMouseTouchEvent(evt) {
+    var getInfoGridFromMouseTouchEvent =
+    function getInfoGridFromMouseTouchEvent(evt) {
       var canvas = evt.currentTarget;
       var rect = canvas.getBoundingClientRect();
       var clientX = evt.clientX || evt.touches[0].clientX;

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -371,8 +371,10 @@ if (!window.clearImmediate) {
     var getInfoGridFromMouseEvent = function getInfoGridFromMouseEvent(evt) {
       var canvas = evt.currentTarget;
       var rect = canvas.getBoundingClientRect();
-      var eventX = evt.clientX - rect.left;
-      var eventY = evt.clientY - rect.top;
+      var clientX = evt.clientX || evt.touches[0].clientX;
+      var clientY = evt.clientX || evt.touches[0].clientY;
+      var eventX = clientX - rect.left;
+      var eventY = clientY - rect.top;
 
       var x = Math.floor(eventX * ((canvas.width / rect.width) || 1) / g);
       var y = Math.floor(eventY * ((canvas.height / rect.height) || 1) / g);

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -368,7 +368,7 @@ if (!window.clearImmediate) {
     var infoGrid = [];
     var hovered;
 
-    var getInfoGridFromMouseEvent = function getInfoGridFromMouseEvent(evt) {
+    var getInfoGridFromMouseTouchEvent = function getInfoGridFromMouseTouchEvent(evt) {
       var canvas = evt.currentTarget;
       var rect = canvas.getBoundingClientRect();
       var clientX = evt.clientX || evt.touches[0].clientX;
@@ -383,7 +383,7 @@ if (!window.clearImmediate) {
     };
 
     var wordcloudhover = function wordcloudhover(evt) {
-      var info = getInfoGridFromMouseEvent(evt);
+      var info = getInfoGridFromMouseTouchEvent(evt);
 
       if (hovered === info) {
         return;
@@ -401,7 +401,7 @@ if (!window.clearImmediate) {
     };
 
     var wordcloudclick = function wordcloudclick(evt) {
-      var info = getInfoGridFromMouseEvent(evt);
+      var info = getInfoGridFromMouseTouchEvent(evt);
       if (!info) {
         return;
       }

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -405,6 +405,7 @@ if (!window.clearImmediate) {
       }
 
       settings.click(info.item, info.dimension, evt);
+      evt.preventDefault();
     };
 
     /* Get points on the grid for a given radius away from the center */
@@ -1046,6 +1047,9 @@ if (!window.clearImmediate) {
 
         if (settings.click) {
           canvas.addEventListener('click', wordcloudclick);
+          canvas.addEventListener('touchstart', wordcloudclick);
+          canvas.addEventListener('touchend', function (e) { e.preventDefault(); });
+          canvas.style.webkitTapHighlightColor = "rgba(0, 0, 0, 0)";
         }
 
         canvas.addEventListener('wordcloudstart', function stopInteraction() {

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1050,8 +1050,10 @@ if (!window.clearImmediate) {
         if (settings.click) {
           canvas.addEventListener('click', wordcloudclick);
           canvas.addEventListener('touchstart', wordcloudclick);
-          canvas.addEventListener('touchend', function (e) { e.preventDefault(); });
-          canvas.style.webkitTapHighlightColor = "rgba(0, 0, 0, 0)";
+          canvas.addEventListener('touchend', function (e) {
+            e.preventDefault();
+          });
+          canvas.style.webkitTapHighlightColor = 'rgba(0, 0, 0, 0)';
         }
 
         canvas.addEventListener('wordcloudstart', function stopInteraction() {


### PR DESCRIPTION
this commits add:
* `touchstart` and `touchend` event to canvas, which implements the `wordcloudclick` method.
* add `-webkit-tap-highlight-color: rgba(0, 0, 0, 0);` style so the canvas won't 'blackout' on touch events.
* fixing the `wordcloudclick` method to get `clientX` & `clientY` for both mouse and touch event.