### PR TITLE
Fix module registration under browserify

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,5 +28,6 @@
   "nonstandard": true,
   "worker": true,
 
-  "-W078": true
+  "-W078": true,
+  "predef": ["define", "module"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordcloud",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tag cloud/Wordle presentation on 2D canvas or HTML",
   "homepage": "http://timdream.org/wordcloud2.js/",
   "author": {

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1136,12 +1136,12 @@ if (!window.clearImmediate) {
   WordCloud.minFontSize = minFontSize;
 
   // Expose the library as an AMD module
-  if (typeof global.define === 'function' && global.define.amd) {
-    global.define('wordcloud', [], function() { return WordCloud; });
-  } else if (typeof global.module !== 'undefined' && global.module.exports) {
-    global.module.exports = WordCloud;
+  if (typeof define === 'function' && define.amd) {
+    define('wordcloud', [], function() { return WordCloud; });
+  } else if (typeof module !== 'undefined' && module.exports) {
+    module.exports = WordCloud;
   } else {
     global.WordCloud = WordCloud;
   }
 
-})(window);
+})(this); //jshint ignore:line


### PR DESCRIPTION
for reference: 850b8979, 113bf93851

When bundled with browserify, module was going down the "browser
global" path, not the "commonjs" path.  The reason was that it was
looking for module as "global.module", but browserify supplies it as an
argument, not a global.  History digging shows that "global." was added
to silence jshint warnings, so I adjusted the environment detection not
to use "global.", and adjusted the jshint rules to prevent it from
complaining about those lines.
