### PR TITLE
Expose WordCloud on the global object to prevent errors with RequireJS

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1155,6 +1155,7 @@ if (!window.clearImmediate) {
 
   // Expose the library as an AMD module
   if (typeof define === 'function' && define.amd) {
+    global.WordCloud = WordCloud;
     define('wordcloud', [], function() { return WordCloud; });
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = WordCloud;


### PR DESCRIPTION
Hi,

this PR exposes `WordCloud` on the global object to get this awesome library working with the (latest) RequireJS version.

It simply exposes `WordCloud` before the `define('wordcloud', [], function() { return WordCloud; });` call.

_Notice_: As it uses a named AMD module called `wordcloud` the _RequireJS_ configuration should look like:

``` javascript
requirejs.config({
  baseUrl: 'bower_components',
  paths: {
    "wordcloud"            : "wordcloud2.js/src/wordcloud2",
  }
});
```

Then the `WordCloud` module is available. I did testings with:
- `RequireJS` version _2.1.15_
- `RequireJS` version _2.2.0_

and `wordcloud2` in version _1.0.5_ and `master`, Final output of `grunt test` is:

``` bash
Took 2102ms to run 23 tests. 23 passed, 0 failed.

Done, without errors.
```

What do you think about merging this PR?
