### PR TITLE
New setting added: rotationSteps

### DIFF
--- a/API.md
+++ b/API.md
@@ -64,6 +64,7 @@ Available options as the property of the `options` object are:
 
 * `minRotation`: If the word should rotate, the minimum rotation (in rad) the text should rotate.
 * `maxRotation`: If the word should rotate, the maximum rotation (in rad) the text should rotate. Set the two value equal to keep all text in one angle.
+* `rotationSteps`: Force the use of a defined number of angles. Set the value equal to 2 in a -90°/90° range means just -90, 0 or 90 will be used. 
 
 ### Randomness
 

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -199,6 +199,7 @@ if (!window.clearImmediate) {
 
       minRotation: - Math.PI / 2,
       maxRotation: Math.PI / 2,
+      rotationSteps: 0,
 
       shuffle: true,
       rotateRatio: 0.1,
@@ -319,6 +320,7 @@ if (!window.clearImmediate) {
 
     /* normalize rotation settings */
     var rotationRange = Math.abs(settings.maxRotation - settings.minRotation);
+    var rotationSteps = Math.abs(Math.floor(settings.rotationSteps));
     var minRotation = Math.min(settings.maxRotation, settings.minRotation);
 
     /* information/object available to all functions, set when start() */
@@ -477,7 +479,12 @@ if (!window.clearImmediate) {
         return minRotation;
       }
 
-      return minRotation + Math.random() * rotationRange;
+      if (rotationSteps > 0) {
+        return minRotation + (1 / Math.floor((Math.random() * rotationSteps) + 1)) * rotationRange;
+      }
+      else {
+        return minRotation + Math.random() * rotationRange;
+      }
     };
 
     var getTextInfo = function getTextInfo(word, weight, rotateDeg) {

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -480,7 +480,9 @@ if (!window.clearImmediate) {
       }
 
       if (rotationSteps > 0) {
-        return minRotation + (1 / Math.floor((Math.random() * rotationSteps) + 1)) * rotationRange;
+        return minRotation + 
+          (1 / Math.floor((Math.random() * rotationSteps) + 1)) *
+          rotationRange;
       }
       else {
         return minRotation + Math.random() * rotationRange;


### PR DESCRIPTION
Allow to use fixed orientation angles.
Setting rotationSteps to 2 on a range of 180° will display just vertical and horizontal words. Setting it to 0 means all angles are allowed (default).