### PR TITLE
Fix incorrect rotation when rotationSteps > 0

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -480,9 +480,10 @@ if (!window.clearImmediate) {
       }
 
       if (rotationSteps > 0) {
+        // Min rotation + zero or more steps * span of one step
         return minRotation + 
-          (1 / Math.floor((Math.random() * rotationSteps) + 1)) *
-          rotationRange;
+          Math.floor(Math.random() * rotationSteps) *
+          rotationRange / (rotationSteps - 1);
       }
       else {
         return minRotation + Math.random() * rotationRange;


### PR DESCRIPTION
### Issue

1. Set `minRotation = -Math.PI/4; maxRotation = Math.PI/4; rotationSteps = 3:`.
2. Observe, how words are tilted -45°, 0° and +15° (instead of +45°).

### Description of change

Fix stepped rotation computation so the result values are as expected.