### PR TITLE
[F] Do not crash anymore when ctx == null

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -96,6 +96,9 @@ if (!window.clearImmediate) {
     }
 
     var ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return false;
+    }
     if (!ctx.getImageData) {
       return false;
     }
@@ -481,7 +484,7 @@ if (!window.clearImmediate) {
 
       if (rotationSteps > 0) {
         // Min rotation + zero or more steps * span of one step
-        return minRotation + 
+        return minRotation +
           Math.floor(Math.random() * rotationSteps) *
           rotationRange / (rotationSteps - 1);
       }


### PR DESCRIPTION
When ctx is null, the package is crashing. I faced the problem testing my app with Jest, getting the following error :

> TypeError: Cannot read property 'getImageData' of null
> 
> at isSupported (node_modules/wordcloud/src/wordcloud2.js:99:13)

This PR just check if ctx is null and return false if it is.