### PR TITLE
Add support to change fontWeight of each word with a callback function

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,7 +30,7 @@ Available options as the property of the `options` object are:
 
 * `list`: List of words/text to paint on the canvas in a 2-d array, in the form of `[word, size]`, e.g. `[['foo', 12], ['bar', 6]]`.
 * `fontFamily`: font to use.
-* `fontWeight`: font weight to use, e.g. `normal`, `bold` or `600`
+* `fontWeight`: font weight to use, can be, as an example, `normal`, `bold` or `600` or a `callback(word, weight, fontSize` specifies different font-weight for each item in the list. 
 * `color`: color of the text, can be any CSS color, or a `callback(word, weight, fontSize, distance, theta)` specifies different color for each item in the list.
   You may also specify colors with built-in keywords: `random-dark` and `random-light`. If this is a DOM cloud, color can also be `null` to disable hardcoding of
   color into span elements (allowing you to customize at the class level).

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -373,6 +373,12 @@ if (!window.clearImmediate) {
         break;
     }
 
+    /* function for getting the font-weight of the text */
+    var getTextFontWeight;
+    if (typeof settings.fontWeight === 'function') {
+      getTextFontWeight = settings.fontWeight;
+    }
+
     /* function for getting the classes of the text */
     var getTextClasses = null;
     if (typeof settings.classes === 'function') {
@@ -527,10 +533,18 @@ if (!window.clearImmediate) {
         })();
       }
 
+      // Get fontWeight that will be used to set fctx.font
+      var fontWeight;
+      if (getTextFontWeight) {
+        fontWeight = getTextFontWeight(word, weight, fontSize);
+      } else {
+        fontWeight = settings.fontWeight;
+      }
+
       var fcanvas = document.createElement('canvas');
       var fctx = fcanvas.getContext('2d', { willReadFrequently: true });
 
-      fctx.font = settings.fontWeight + ' ' +
+      fctx.font = fontWeight + ' ' +
         (fontSize * mu).toString(10) + 'px ' + settings.fontFamily;
 
       // Estimate the dimension of the text with measureText().
@@ -583,7 +597,7 @@ if (!window.clearImmediate) {
 
       // Once the width/height is set, ctx info will be reset.
       // Set it again here.
-      fctx.font = settings.fontWeight + ' ' +
+      fctx.font = fontWeight + ' ' +
         (fontSize * mu).toString(10) + 'px ' + settings.fontFamily;
 
       // Fill the text into the fcanvas.
@@ -714,9 +728,17 @@ if (!window.clearImmediate) {
         color = settings.color;
       }
 
+      // get fontWeight that will be used to set ctx.font and font style rule
+      var fontWeight;
+      if (getTextFontWeight) {
+        fontWeight = getTextFontWeight(word, weight, fontSize);
+      } else {
+        fontWeight = settings.fontWeight;
+      }
+
       var classes;
       if (getTextClasses) {
-        classes = getTextClasses(word, weight, fontSize, distance, theta);
+        classes = getTextClasses(word, weight, fontSize);
       } else {
         classes = settings.classes;
       }
@@ -739,7 +761,7 @@ if (!window.clearImmediate) {
           ctx.save();
           ctx.scale(1 / mu, 1 / mu);
 
-          ctx.font = settings.fontWeight + ' ' +
+          ctx.font = fontWeight + ' ' +
                      (fontSize * mu).toString(10) + 'px ' + settings.fontFamily;
           ctx.fillStyle = color;
 
@@ -782,7 +804,7 @@ if (!window.clearImmediate) {
           var styleRules = {
             'position': 'absolute',
             'display': 'block',
-            'font': settings.fontWeight + ' ' +
+            'font': fontWeight + ' ' +
                     (fontSize * info.mu) + 'px ' + settings.fontFamily,
             'left': ((gx + info.gw / 2) * g + info.fillTextOffsetX) + 'px',
             'top': ((gy + info.gh / 2) * g + info.fillTextOffsetY) + 'px',

--- a/test/unit/options.js
+++ b/test/unit/options.js
@@ -96,6 +96,19 @@ test('color can be set as a function', function() {
   WordCloud(setupTest('color-as-function'), options);
 });
 
+test('fontWeight can be set as a function', function() {
+  var options = getTestOptions();
+  options.fontWeight = function (word, weight, fontSize) {
+    if (weight > 15) {
+      return 'bold';
+    } else {
+      return 'normal'
+    }
+  };
+
+  WordCloud(setupTest('font-weight-as-function'), options);
+});
+
 test('classes can be set as a function', function() {
   var options = getTestOptions();
   options.classes = function (word, weight, fontSize, radius, theta) {


### PR DESCRIPTION
- Add support to change fontWeight with a callback. Callback don't include `distance` and `theta` because on the `getTextInfo` function those values weren't available. I didn't look in deep to `distance` and `theta` variables, let me know by giving me some guide if is possible to add those to the callback function if needed.
- I've tried to keep the same code structure that is being used across the lib. 

`grunt compare --base-commit=gh-pages` made the comparison successfully ✅ 

Here you can see 2 variations of fontWeight being applied: 
 - [**Variation 1**](https://cl.ly/0B3B2s3w0f3K)
 - [**Variation 2**](https://cl.ly/1C3h05331D1i)

This PR is related with issue #123.