### PR TITLE
Fix for deprecated event initialization method

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,8 +30,8 @@ Available options as the property of the `options` object are:
 
 * `list`: List of words/text to paint on the canvas in a 2-d array, in the form of `[word, size]`.
 	* e.g. `[['foo', 12], ['bar', 6]]`
-	* Optionally, you can also send additonal elements in the array which can be used in the callback functions of `click` and `hover` interactions. The array positions of `word` and `size` must remain unchanged.
-	* e.g. `[['foo', 12,'http://google.com?q=foo'], ['bar', 6, 'http://google.com?q=bar']]`. 
+	* Optionally, you can send additional data as array elements, in the form of `[word, size, data1, data2, ... ]` which can then be used in the callback functions of `click` and `hover` interactions.
+	* e.g. `[['foo', 12, 'http://google.com?q=foo'], ['bar', 6, 'http://google.com?q=bar']]`. 
 * `fontFamily`: font to use.
 * `fontWeight`: font weight to use, can be, as an example, `normal`, `bold` or `600` or a `callback(word, weight, fontSize` specifies different font-weight for each item in the list. 
 * `color`: color of the text, can be any CSS color, or a `callback(word, weight, fontSize, distance, theta)` specifies different color for each item in the list.

--- a/API.md
+++ b/API.md
@@ -28,7 +28,10 @@ Available options as the property of the `options` object are:
 
 ### Presentation
 
-* `list`: List of words/text to paint on the canvas in a 2-d array, in the form of `[word, size]`, e.g. `[['foo', 12], ['bar', 6]]`.
+* `list`: List of words/text to paint on the canvas in a 2-d array, in the form of `[word, size]`.
+	* e.g. `[['foo', 12], ['bar', 6]]`
+	* Optionally, you can also send additonal elements in the array which can be used in the callback functions of `click` and `hover` interactions. The array positions of `word` and `size` must remain unchanged.
+	* e.g. `[['foo', 12,'http://google.com?q=foo'], ['bar', 6, 'http://google.com?q=bar']]`. 
 * `fontFamily`: font to use.
 * `fontWeight`: font weight to use, can be, as an example, `normal`, `bold` or `600` or a `callback(word, weight, fontSize` specifies different font-weight for each item in the list. 
 * `color`: color of the text, can be any CSS color, or a `callback(word, weight, fontSize, distance, theta)` specifies different color for each item in the list.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This library is a spin-off project from [HTML5 Word Cloud](https://github.com/ti
 
 ## Simple usage
 
-Load `wordcloud.js` script to the web page, and run:
+Download the latest `wordcloud2.js` file from the src folder in this repository.
+
+Load `wordcloud2.js` script to the web page, and run:
 
     WordCloud(document.getElementById('my_canvas'), { list: list } );
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is a spin-off project from [HTML5 Word Cloud](https://github.com/ti
 
 ## Simple usage
 
-Download the latest `wordcloud2.js` file from the src folder in this repository.
+Download the latest `wordcloud2.js` file from the `src` folder in this repository.
 
 Load `wordcloud2.js` script to the web page, and run:
 

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -987,18 +987,20 @@ if (!window.clearImmediate) {
 
     /* Send DOM event to all elements. Will stop sending event and return
        if the previous one is canceled (for cancelable events). */
-    var sendEvent = function sendEvent(type, cancelable, detail) {
+    var sendEvent = function sendEvent(type, cancelable, details) {
       if (cancelable) {
         return !elements.some(function(el) {
-          var evt = document.createEvent('CustomEvent');
-          evt.initCustomEvent(type, true, cancelable, detail || {});
-          return !el.dispatchEvent(evt);
+          var event = new CustomEvent(type, {
+            detail: details || {}
+          });
+          return !el.dispatchEvent(event);
         }, this);
       } else {
         elements.forEach(function(el) {
-          var evt = document.createEvent('CustomEvent');
-          evt.initCustomEvent(type, true, cancelable, detail || {});
-          el.dispatchEvent(evt);
+          var event = new CustomEvent(type, {
+            detail: details || {}
+          });
+          el.dispatchEvent(event);
         }, this);
       }
     };


### PR DESCRIPTION
The `initCustomEvent()` method is deprecated, therefore replaced it with `new CustomEvent()` event constructor.

Also,  updated API documentation to mention how additional data can be passed to the words list, so that it can be used when the `click` or `hover` handlers are invoked.