### PR TITLE
removed touchstart and touchend listeners

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1121,14 +1121,8 @@ if (!window.clearImmediate) {
           canvas.addEventListener('mousemove', wordcloudhover);
         }
 
-        var touchend = function (e) {
-          e.preventDefault();
-        };
-
         if (settings.click) {
           canvas.addEventListener('click', wordcloudclick);
-          canvas.addEventListener('touchstart', wordcloudclick);
-          canvas.addEventListener('touchend', touchend);
           canvas.style.webkitTapHighlightColor = 'rgba(0, 0, 0, 0)';
         }
 
@@ -1137,8 +1131,6 @@ if (!window.clearImmediate) {
 
           canvas.removeEventListener('mousemove', wordcloudhover);
           canvas.removeEventListener('click', wordcloudclick);
-          canvas.removeEventListener('touchstart', wordcloudclick);
-          canvas.removeEventListener('touchend', touchend);
           hovered = undefined;
         });
       }


### PR DESCRIPTION
in order to allow touch device users to move wordcloud by toch swipe
instead of directly interpreting all touch events as clicks on a wordcloud item

See also issue:
https://github.com/timdream/wordcloud2.js/issues/139