### PR TITLE
shrink to fit into canvas

### DIFF
--- a/API.md
+++ b/API.md
@@ -50,6 +50,7 @@ Available options as the property of the `options` object are:
 * `gridSize`: size of the grid in pixels for marking the availability of the canvas — the larger the grid size, the bigger the gap between words.
 * `origin`: origin of the “cloud” in `[x, y]`.
 * `drawOutOfBound`: set to `true` to allow word being draw partly outside of the canvas. Allow word bigger than the size of the canvas to be drawn.
+* `shrinkToFit`: set to `true` to shrink the word so it will fit into canvas. Best if `drawOutOfBound` is set to `false`. :warning: This word will now have lower `weight`.
 
 ### Mask
 

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -190,6 +190,7 @@ if (!window.clearImmediate) {
 
       gridSize: 8,
       drawOutOfBound: false,
+      shrinkToFit: false,
       origin: null,
 
       drawMask: false,
@@ -980,6 +981,14 @@ if (!window.clearImmediate) {
           // leave putWord() and return true
           return true;
         }
+      }
+      if (settings.shrinkToFit) {
+        if (Array.isArray(item)) {
+          item[1] = item[1] * 3 / 4;
+        } else {
+          item.weight = item.weight * 3 / 4;
+        }
+        return putWord(item);
       }
       // we tried all distances but text won't fit, return false
       return false;


### PR DESCRIPTION
I know regarding [your contribution guidelines](https://github.com/timdream/wordcloud2.js/blob/gh-pages/CONTRIBUTING.md#virtual-canvas-never-miss-a-word-thats-too-big-and-forget-about-weightfactor) there should be no PRs to fix this issue. But sometimes when using following list:
```html
<!DOCTYPE html>
<html>

  <head>
	<script src="wordcloud2.js"></script>
  </head>

  <body>
	<canvas id="foo" width="400" height="400"></canvas>
	<script>
		WordCloud(document.getElementById('foo'), { list: [['Sachsen', 238], ['Menschen', 159]], weightFactor: 0.4, color: 'random-dark' } );
	</script>
  </body>

</html>
```
the second word `Menschen` is not show, with following javascript error
```javascript
Uncaught ReferenceError: resizeToFit is not defined
    at putWord (wordcloud2.js:985)
    at Array.loop (wordcloud2.js:1185)
    at setZeroTimeoutMessage (wordcloud2.js:53)
```
For my project it is more important to see all words even if the `weight` is not correct, instead of skipping the word. By default this feature is set to `false`. Maybe if needed an additional `console.log` can be added, so the user will see that the weight was shrinked for a specific word