### PR TITLE
Fix use of shrinkToFit together with drawOutOfBounds false

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -928,7 +928,7 @@ if (!window.clearImmediate) {
       // If drawOutOfBound is set to false,
       // skip the loop if we have already know the bounding box of
       // word is larger than the canvas.
-      if (!settings.drawOutOfBound) {
+      if (!settings.drawOutOfBound && !settings.shrinkToFit) {
         var bounds = info.bounds;
         if ((bounds[1] - bounds[3] + 1) > ngx ||
           (bounds[2] - bounds[0] + 1) > ngy) {

--- a/test/unit/basics.js
+++ b/test/unit/basics.js
@@ -2,6 +2,8 @@
 
 module('Basics');
 
+var testElement;
+
 test('Test runs without any extra parameters.', function() {
   var options = getTestOptions();
   WordCloud(setupTest('default-testing-config'), options);
@@ -12,4 +14,33 @@ test('Empty list results no output.', function() {
   options.list = [];
 
   WordCloud(setupTest('empty'), options);
+});
+
+function createTestHtmlElement() {
+  if (testElement) {
+    document.getElementsByTagName('body')[0].removeChild(testElement);
+  }
+  testElement = document.createElement('div');
+  testElement.id = 'test-span';
+  testElement.style.width = '300px';
+  testElement.style.height = '300px';
+  document.getElementsByTagName('body')[0].appendChild(testElement);
+
+  return testElement;
+}
+
+test('shrinkToFit shrinks words to fit grid', function() {
+  var testElement = createTestHtmlElement();
+  var options = getTestOptions();
+  options.drawOutOfBound = false;
+  options.shrinkToFit = true;
+  options.weightFactor = 15;
+
+  testElement.addEventListener('wordcloudstop', function () {
+    ok(testElement.innerText.indexOf(options.list[0][0]) !== -1, 'Word ' + options.list[0][0] + ' should be rendered.');
+    start();
+  });
+
+  stop();
+  WordCloud(testElement, options);
 });


### PR DESCRIPTION
When having big words on a small grid, using shrinkToFit: true should,
together with drawOutOfBounds: false, ensure, that the words are all rendered
within the available space. This should be done by shrinking the words
as much as needed to fit the available space.

However, when drawOutOfBounds is set to false, the code before this commit
simply did not render the word at all if it did not fit the grid (anymore).

This commit fixes the behaviour so that when setting shrinkToFit to true and
drawOutOfBounds to false will correctly render the words on the available space.

Co-authored-by: Arne <arne.wohlert@oss.volkswagen.com>