### PR TITLE
doc: remove outdated and misleading notice about Interactive API doc

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,8 +83,6 @@ Available presents are `circle` (default), `cardioid` (apple or heart shape curv
 
 ### Interactive
 
-Notice: `hover` and `click` are currently only for HTML5 canvas word clouds.
-
 * `hover`: callback to call when the cursor enters or leaves a region occupied by a word. The callback will take arguments `callback(item, dimension, event)`, where `event` is the original `mousemove` event.
 * `click`: callback to call when the user clicks on a word. The callback will take arguments `callback(item, dimension, event)`, where `event` is the original `click` event.
 


### PR DESCRIPTION
event 'hover' and 'click' is fine both element and canvas