### PR TITLE
feat: allow multiple timers for multi-canvas rendering

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -81,9 +81,7 @@ if (!window.clearImmediate) {
     // "clearZeroTimeout" is implement on the previous block ||
     // fallback
     function clearImmediateFallback (timer) {
-      for (const timerId in timer) {
-        window.clearTimeout(timer[timerId])
-      }
+      window.clearTimeout(timer)
     }
   })()
 }

--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -81,7 +81,9 @@ if (!window.clearImmediate) {
     // "clearZeroTimeout" is implement on the previous block ||
     // fallback
     function clearImmediateFallback (timer) {
-      window.clearTimeout(timer)
+      for (const timerId in timer) {
+        window.clearTimeout(timer[timerId])
+      }
     }
   })()
 }
@@ -168,11 +170,13 @@ if (!window.clearImmediate) {
     return arr
   }
 
-  var timer;
+  var timer = {};
   var WordCloud = function WordCloud (elements, options) {
     if (!isSupported) {
       return
     }
+
+    var timerId = Math.floor(Math.random() * Date.now())
 
     if (!Array.isArray(elements)) {
       elements = [elements]
@@ -1147,7 +1151,6 @@ if (!window.clearImmediate) {
 
         canvas.addEventListener('wordcloudstart', function stopInteraction () {
           canvas.removeEventListener('wordcloudstart', stopInteraction)
-
           canvas.removeEventListener('mousemove', wordcloudhover)
           canvas.removeEventListener('click', wordcloudclick)
           hovered = undefined
@@ -1178,16 +1181,16 @@ if (!window.clearImmediate) {
 
       var anotherWordCloudStart = function anotherWordCloudStart () {
         removeEventListener('wordcloudstart', anotherWordCloudStart)
-        stoppingFunction(timer)
+        stoppingFunction(timer[timerId])
       }
 
       addEventListener('wordcloudstart', anotherWordCloudStart)
-      timer = loopingFunction(function loop () {
+      timer[timerId] = loopingFunction(function loop () {
         if (i >= settings.list.length) {
-          stoppingFunction(timer)
+          stoppingFunction(timer[timerId])
           sendEvent('wordcloudstop', false)
           removeEventListener('wordcloudstart', anotherWordCloudStart)
-
+          delete timer[timerId];
           return
         }
         escapeTime = (new Date()).getTime()
@@ -1197,15 +1200,16 @@ if (!window.clearImmediate) {
           drawn: drawn
         })
         if (exceedTime() || canceled) {
-          stoppingFunction(timer)
+          stoppingFunction(timer[timerId])
           settings.abort()
           sendEvent('wordcloudabort', false)
           sendEvent('wordcloudstop', false)
           removeEventListener('wordcloudstart', anotherWordCloudStart)
+          delete timer[timerId]
           return
         }
         i++
-        timer = loopingFunction(loop, settings.wait)
+        timer[timerId] = loopingFunction(loop, settings.wait)
       }, settings.wait)
     }
 
@@ -1217,7 +1221,9 @@ if (!window.clearImmediate) {
   WordCloud.minFontSize = minFontSize
   WordCloud.stop = function stop () {
     if (timer) {
-      window.clearImmediate(timer)
+      for (const timerId in timer) {
+        window.clearImmediate(timer[timerId])
+      }
     }
   }
 


### PR DESCRIPTION
This PR allows multiple concurrent rendering by allowing different timers to be added whenever the WordCloud function is called. 
When I was trying to render wordcloud in multiple canvases in React - separate components - I noticed the single timer instance can end up stopping the wrong canvas from putting words.