### PR TITLE
replace const by var for IE support

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1219,7 +1219,7 @@ if (!window.clearImmediate) {
   WordCloud.minFontSize = minFontSize
   WordCloud.stop = function stop () {
     if (timer) {
-      for (const timerId in timer) {
+      for (var timerId in timer) {
         window.clearImmediate(timer[timerId])
       }
     }


### PR DESCRIPTION
As mentioned on https://github.com/timdream/wordcloud2.js/pull/174, `const` was introduced and it breaks support for IE11.