### PR TITLE
fix: maxRadius to avoid overflow

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -1053,7 +1053,7 @@ if (!window.clearImmediate) {
         : [ngx / 2, ngy / 2]
 
       // Maxium radius to look for space
-      maxRadius = Math.floor(Math.sqrt(ngx * ngx + ngy * ngy))
+      maxRadius = Math.floor(Math.max(ngx, ngy) / 2)
 
       /* Clear the canvas only if the clearCanvas is set,
          if not, update the grid to the current canvas state */


### PR DESCRIPTION
This PR fixes `maxRadius` so that text does not overflows the shape.

## Before

Take `shape: 'circle'` and `'diamond'` for example, when text list contains too many text, it will overflows the shape.

<img width="403" alt="circle before" src="https://user-images.githubusercontent.com/779050/146726244-37d7c109-72a4-4a2a-a8d1-d3f573cc6807.png">

<img width="404" alt="diamod before" src="https://user-images.githubusercontent.com/779050/146726274-f400ded8-e10e-4f72-ac69-d547bc4f1380.png">

## After

<img width="404" alt="circle after" src="https://user-images.githubusercontent.com/779050/146726365-81605fe4-9863-472b-b270-d011cb131910.png">

<img width="404" alt="diamond after" src="https://user-images.githubusercontent.com/779050/146726393-001d3154-a17d-46f6-8dc4-ed5232c41d31.png">

### Test case used:

```html
<html>
  <head>
    <style>
      body {
        margin: 0;
      }
      #main {
        border: 1px solid red;
        width: 400px;
        height: 400px;
      }
      #circle {
        position: absolute;
        left: 0;
        top: 0;
        width: 400px;
        height: 400px;
        border-radius: 200px;
        border: 1px solid blue;
      }
      #diamond {
        position: absolute;
        left: 58px;
        top: 58px;
        width: 282.8px;
        height: 282.8px;
        transform: rotate(45deg);
        transform-origin: 50% 50%;
        border: 1px solid blue;
      }
    </style>
  </head>
  <body>
    <canvas id="main"></canvas>
    <!-- <div id="circle"></div> -->
    <div id="diamond"></div>
    <script src="./src/wordcloud2.js"></script>
    <script>
      var data = [];
      for (var i = 0; i < 400; i++) {
        data.push([
          'wordcloud'.slice(0, Math.ceil(Math.random() * 9)),
          Math.round(Math.random() * 40) + 5,
        ]);
      }

      var canvas = document.getElementById('main');
      canvas.width = 800;
      canvas.height = 800;

      WordCloud(canvas, {
        list: data,
        ellipticity: 1,
        gridSize: 4,
        shape: 'diamond',
      });
    </script>
  </body>
</html>
```
