### PR TITLE
fix negative values when hovering the canvas

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -417,7 +417,9 @@ if (!window.clearImmediate) {
         clientX = evt.clientX
         clientY = evt.clientY
       }
-      var eventX = clientX - rect.left
+
+      var eventXvalue = clientX - rect.left
+      var eventX = eventXvalue < 0 ? 0 : eventXvalue
       var eventY = clientY - rect.top
 
       var x = Math.floor(eventX * ((canvas.width / rect.width) || 1) / g)


### PR DESCRIPTION
Sometimes the rect position will return greater value and when we substract it to the mouse position the X value was -1 so it caused an error.

Just a little touch to control this.